### PR TITLE
Add config system and the ability to disable mods

### DIFF
--- a/FEZ.HAT.mm.csproj
+++ b/FEZ.HAT.mm.csproj
@@ -86,6 +86,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\ConfigHelper.cs" />
     <Compile Include="Helpers\DrawingTools.cs" />
     <Compile Include="Helpers\InputHelper.cs" />
     <Compile Include="Installers\IHatInstaller.cs" />

--- a/Helpers/ConfigHelper.cs
+++ b/Helpers/ConfigHelper.cs
@@ -46,17 +46,17 @@ namespace HatModLoader.Helpers
         }
 
         public static void SetModConfig(ModConfig newConfig)
-		{
+        {
             for (int i = 0; i < Config.Mods.Count; i++)
-			{
+            {
                 if (Config.Mods[i].Name == newConfig.Name && Config.Mods[i].Version == newConfig.Version)
-				{
+                {
                     Config.Mods[i] = newConfig;
                     return;
-				}
+                }
             }
             Config.Mods.Add(newConfig);
-		}
+        }
 
         public static void LoadHatConfig()
         {

--- a/Helpers/ConfigHelper.cs
+++ b/Helpers/ConfigHelper.cs
@@ -45,6 +45,19 @@ namespace HatModLoader.Helpers
             return newModConfig;
         }
 
+        public static void SetModConfig(ModConfig newConfig)
+		{
+            for (int i = 0; i < Config.Mods.Count; i++)
+			{
+                if (Config.Mods[i].Name == newConfig.Name && Config.Mods[i].Version == newConfig.Version)
+				{
+                    Config.Mods[i] = newConfig;
+                    return;
+				}
+            }
+            Config.Mods.Add(newConfig);
+		}
+
         public static void LoadHatConfig()
         {
             HatConfig NewConfig;
@@ -78,6 +91,7 @@ namespace HatModLoader.Helpers
                 ModConfig mod = NewConfig.Mods[i];
                 if (!mod.Disabled.HasValue)
                     mod.Disabled = false;
+                NewConfig.Mods[i] = mod;
             }
 
             Config = NewConfig;

--- a/Helpers/ConfigHelper.cs
+++ b/Helpers/ConfigHelper.cs
@@ -30,7 +30,7 @@ namespace HatModLoader.Helpers
 
         public static HatConfig Config { get; private set; }
 
-        public static ModConfig? GetModConfig(string Name, string Version)
+        public static ModConfig GetModConfig(string Name, string Version)
         {
             foreach (ModConfig modConfig in Config.Mods)
             {
@@ -76,7 +76,7 @@ namespace HatModLoader.Helpers
             for (int i = 0; i < NewConfig.Mods.Count; i++)
             {
                 ModConfig mod = NewConfig.Mods[i];
-                if (mod.Disabled == null)
+                if (!mod.Disabled.HasValue)
                     mod.Disabled = false;
             }
 

--- a/Helpers/ConfigHelper.cs
+++ b/Helpers/ConfigHelper.cs
@@ -1,0 +1,109 @@
+﻿using Common;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace HatModLoader.Helpers
+{
+    public static class ConfigHelper
+    {
+        public const string HatConfigFileName = "HatConfig.xml";
+
+        [Serializable]
+        public struct ModConfig
+        {
+            [XmlAttribute] public string Name;
+            [XmlAttribute] public string Version;
+            public bool? Disabled;
+        }
+
+        [Serializable]
+        public struct HatConfig
+        {
+            public List<ModConfig> Mods;
+        }
+
+        public static HatConfig Config { get; private set; }
+
+        public static ModConfig? GetModConfig(string Name, string Version)
+        {
+            foreach (ModConfig modConfig in Config.Mods)
+            {
+                if (modConfig.Name == Name && modConfig.Version == Version)
+                    return modConfig;
+            }
+            ModConfig newModConfig = new ModConfig();
+            newModConfig.Name = Name;
+            newModConfig.Version = Version;
+            newModConfig.Disabled = false;
+            Config.Mods.Add(newModConfig);
+            return newModConfig;
+        }
+
+        public static void LoadHatConfig()
+        {
+            HatConfig NewConfig;
+            if (!File.Exists(GetHatConfigFilePath()))
+            {
+                Logger.Log("HAT", "Config file doesn't exist, loading blank configuration");
+                NewConfig = new HatConfig();
+            }
+            else
+            {
+                try
+                {
+                    using (StreamReader reader = new StreamReader(GetHatConfigFilePath()))
+                    {
+                        XmlSerializer serializer = new XmlSerializer(typeof(HatConfig));
+                        NewConfig = (HatConfig)serializer.Deserialize(reader);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Log("HAT", $"Exception deserializing config file, {e.Message}");
+                    NewConfig = new HatConfig();
+                }
+            }
+
+            // Cleanup configuration and fill in missing details
+            if (NewConfig.Mods == null)
+                NewConfig.Mods = new List<ModConfig>();
+            for (int i = 0; i < NewConfig.Mods.Count; i++)
+            {
+                ModConfig mod = NewConfig.Mods[i];
+                if (mod.Disabled == null)
+                    mod.Disabled = false;
+            }
+
+            Config = NewConfig;
+        }
+
+        public static bool SaveHatConfig()
+        {
+            try
+            {
+                using (StreamWriter writer = new StreamWriter(GetHatConfigFilePath()))
+                {
+                    XmlSerializer serializer = new XmlSerializer(typeof(HatConfig));
+                    serializer.Serialize(writer, Config);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log("HAT", $"FAILED to save HAT config, ${e.Message}");
+                return false;
+            }
+            return true;
+        }
+
+        public static string GetHatConfigFilePath()
+        {
+            return Path.Combine(Util.LocalConfigFolder, HatConfigFileName);
+        }
+    }
+}

--- a/Patches/FezLogo.cs
+++ b/Patches/FezLogo.cs
@@ -149,7 +149,10 @@ namespace FezGame.Components
             Viewport viewport = DrawingTools.GetViewport();
             int modCount = Hat.Instance.Mods.Count;
             string hatText = $"HAT Mod Loader, version {Hat.Version}, {modCount} mod{(modCount != 1 ? "s" : "")} installed";
-            if (modCount == 69) hatText += "... nice";
+            int enabledModCount = Hat.Instance.EnabledMods.Count;
+            if (enabledModCount != modCount)
+                hatText += $", {enabledModCount} mod{(enabledModCount != 1 ? "s" : "")} enabled";
+            if (enabledModCount == 69) hatText += "... nice";
             Color textColor = Color.Lerp(Color.White, Color.Black, alpha);
 
             DrawingTools.BeginBatch();

--- a/Source/Hat.cs
+++ b/Source/Hat.cs
@@ -52,6 +52,7 @@ namespace HatModLoader.Source
             if(Mods.Count == 0)
             {
                 Logger.Log("HAT", $"No mods have been found in the directory.");
+                EnabledMods = new List<Mod>();
                 return;
             }
 
@@ -144,16 +145,14 @@ namespace HatModLoader.Source
         }
 
         private void DisableMods()
-        {
+		{
             foreach (Mod mod in Mods)
-            {
-                ModConfig? config = ConfigHelper.GetModConfig(mod.Info.Name, mod.Info.Version);
-                if (!config.HasValue)
-                    continue;
-                if (config.Value.Disabled.HasValue && config.Value.Disabled.Value == true)
+			{
+                ModConfig config = ConfigHelper.GetModConfig(mod.Info.Name, mod.Info.Version);
+                if (config.Disabled.HasValue && config.Disabled.Value == true)
                     mod.IsEnabled = false;
-            }
-        }
+			}
+		}
 
         private void DisableDuplicates()
         {

--- a/Source/Hat.cs
+++ b/Source/Hat.cs
@@ -145,14 +145,14 @@ namespace HatModLoader.Source
         }
 
         private void DisableMods()
-		{
+        {
             foreach (Mod mod in Mods)
-			{
+            {
                 ModConfig config = ConfigHelper.GetModConfig(mod.Info.Name, mod.Info.Version);
                 if (config.Disabled.HasValue && config.Disabled.Value == true)
                     mod.IsEnabled = false;
-			}
-		}
+            }
+        }
 
         private void DisableDuplicates()
         {

--- a/Source/Mod.cs
+++ b/Source/Mod.cs
@@ -69,6 +69,8 @@ namespace HatModLoader.Source
         public bool IsAssetMod => Assets.Count > 0;
         public bool IsCodeMod => RawAssembly != null;
 
+        public bool IsEnabled = true;
+
         public Mod(Hat modLoader)
         {
             ModLoader = modLoader;


### PR DESCRIPTION
This adds the ability to enable/disable mods through the Mods menu, as well as a basic xml-based configuration system for HAT. I plan on expanding this to add the ability for mods to create custom config menus and/or store configuration data inside the HatConfig file (potentially removing the need for files like `FezugBinds`).

Feel free to pick apart and destroy my code here lmao, I'm not confident about some things and definitely felt like some stuff I did were hacks