### PR TITLE
CI artifact improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
     branches: 
     - '**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: 
     - '**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
           New-Item -Path artifact -ItemType Directory -Force
           Copy-Item -Path 'bin/Debug/*' -Destination artifact -Recurse
           Copy-Item -Path 'scripts/*' -Destination artifact -Recurse
-          Compress-Archive -Path artifact/* -DestinationPath HAT.zip
+          Compress-Archive -Path artifact/ -DestinationPath HAT.zip
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,5 +43,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: HAT
-          path: HAT.zip
+          path: artifact/
           if-no-files-found: error


### PR DESCRIPTION
- For some reason, the wildcard in the `Compress-Archive` PowerShell command caused the output artifact to become corrupted (or at least on Linux). This fixes that.
- When unzipping the downloaded artifact (`HAT.zip`), it should now unzip into a `HAT/` folder which contains all of the dependencies inside, like so:

<img width="1958" height="774" alt="image" src="https://github.com/user-attachments/assets/ffddc5d8-c02a-4b9d-a5d4-c025935ec363" />
