### PR TITLE
Add support for entrypoint component class

### DIFF
--- a/Source/ModDefinition/CodeMod.cs
+++ b/Source/ModDefinition/CodeMod.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Common;
 using FezEngine.Tools;
 using HatModLoader.Source.AssemblyResolving;
 using HatModLoader.Source.FileProxies;
@@ -19,7 +20,7 @@ namespace HatModLoader.Source.ModDefinition
             RawAssembly = rawAssembly;
         }
 
-        public void Initialize(Game game)
+        public void Initialize(Game game, string entrypoint)
         {
             if (RawAssembly == null || RawAssembly.Length < 1)
             {
@@ -33,8 +34,27 @@ namespace HatModLoader.Source.ModDefinition
             
             Assembly = Assembly.Load(RawAssembly);
             Components = [];
+
+            Type[] types;
+            if (!string.IsNullOrEmpty(entrypoint))
+            {
+                if (!Assembly.GetTypes().Any(t => t.FullName?.Equals(entrypoint) ?? false))
+                {
+                    throw new ArgumentException($"The entrypoint name is not a fully qualified name: {entrypoint}");
+                }
+                
+                // Entrypoint class may load other components (services) via Game.Components (Game.Services)
+                Logger.Log("HAT", LogSeverity.Information, $"Starting at entrypoint {entrypoint}.");
+                types = [Assembly.GetType(entrypoint)];
+            }
+            else
+            {
+                // Use backward compatible method
+                Logger.Log("HAT", LogSeverity.Warning, "No entrypoint was specified. Loading all public components...");
+                types = Assembly.GetExportedTypes();
+            }
             
-            foreach (var type in Assembly.GetExportedTypes())
+            foreach (var type in types)
             {
                 if (typeof(GameComponent).IsAssignableFrom(type) && type.IsPublic && !type.IsAbstract)
                 {

--- a/Source/ModDefinition/Metadata.cs
+++ b/Source/ModDefinition/Metadata.cs
@@ -31,6 +31,8 @@ namespace HatModLoader.Source.ModDefinition
         }
 
         public string LibraryName { get; set; }
+        
+        public string Entrypoint { get; set; }
 
         public DependencyInfo[] Dependencies { get; set; }
         

--- a/Source/ModDefinition/ModContainer.cs
+++ b/Source/ModDefinition/ModContainer.cs
@@ -30,7 +30,7 @@ public class ModContainer : IDisposable
         {
             _assemblyResolver = new ModInternalAssemblyResolver(this);
             AssemblyResolverRegistry.Register(_assemblyResolver);
-            CodeMod?.Initialize(game);
+            CodeMod?.Initialize(game, Metadata.Entrypoint);
         }
     }
 


### PR DESCRIPTION
This PR adds support for loading mod from a class as an entry point specified in `Metadata.xml` as follows:

```xml
<Metadata>
    <Entrypoint>FEZUG.FEZUG</Entrypoint>
</Metadata>
```

The value of the entry point should be a fully qualified name of the class. Mod components should be loaded from the entry point via the `Game.Components` or `Game.Services` collections.

If it is not specified, loading is performed as before.