### PR TITLE
Add support for loading native libraries

### DIFF
--- a/Source/AssemblyResolving/ModInternalAssemblyResolver.cs
+++ b/Source/AssemblyResolving/ModInternalAssemblyResolver.cs
@@ -56,8 +56,9 @@ namespace HatModLoader.Source.AssemblyResolving
             foreach (var file in _mod.FileProxy.EnumerateFiles(""))
             {
                 if (
-                    file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || 
-                    file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                    (file.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || 
+                    file.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) &&
+                    _mod.FileProxy.IsDotNetAssembly(file)
                 ) {
                     yield return file;
                 }

--- a/Source/FileProxies/DirectoryFileProxy.cs
+++ b/Source/FileProxies/DirectoryFileProxy.cs
@@ -1,4 +1,6 @@
-﻿namespace HatModLoader.Source.FileProxies
+﻿using System.Reflection;
+
+namespace HatModLoader.Source.FileProxies
 {
     internal class DirectoryFileProxy : IFileProxy
     {
@@ -35,6 +37,30 @@
         public Stream OpenFile(string localPath)
         {
             return File.OpenRead(Path.Combine(modDirectory, localPath));
+        }
+
+        public IntPtr LoadLibrary(string localPath)
+        {
+            return NativeLibraryInterop.Load(Path.Combine(modDirectory, localPath));
+        }
+
+        public void UnloadLibrary(IntPtr handle)
+        {
+            NativeLibraryInterop.Free(handle);
+        }
+
+        public bool IsDotNetAssembly(string localPath)
+        {
+            try
+            {
+                var fullPath = Path.Combine(modDirectory, localPath);
+                AssemblyName.GetAssemblyName(fullPath);
+                return true;
+            }
+            catch (BadImageFormatException)
+            {
+                return false;   // Native library file
+            }
         }
 
         public void Dispose() { }

--- a/Source/FileProxies/IFileProxy.cs
+++ b/Source/FileProxies/IFileProxy.cs
@@ -7,5 +7,8 @@
         public IEnumerable<string> EnumerateFiles(string localPath);
         public bool FileExists(string localPath);
         public Stream OpenFile(string localPath);
+        public IntPtr LoadLibrary(string localPath);
+        public void UnloadLibrary(IntPtr handle);
+        public bool IsDotNetAssembly(string localPath);
     }
 }

--- a/Source/ModDefinition/Metadata.cs
+++ b/Source/ModDefinition/Metadata.cs
@@ -1,4 +1,5 @@
-﻿using System.Xml.Serialization;
+﻿using System.Runtime.InteropServices;
+using System.Xml.Serialization;
 using Common;
 using HatModLoader.Source.FileProxies;
 
@@ -33,6 +34,8 @@ namespace HatModLoader.Source.ModDefinition
         public string LibraryName { get; set; }
 
         public DependencyInfo[] Dependencies { get; set; }
+        
+        public NativeLibrary[] NativeDependencies { get; set; }
         
         public static bool TryLoad(IFileProxy proxy, out Metadata metadata)
         {
@@ -86,6 +89,44 @@ namespace HatModLoader.Source.ModDefinition
                     }
                 }
             }
+        }
+        
+        [Serializable]
+        public struct NativeLibrary
+        {
+            [XmlAttribute] public Architecture Architecture { get; set; }
+    
+            [XmlIgnore] public OSPlatform Platform { get; set; }
+            
+            [XmlAttribute("Platform")]
+            public string PlatformString
+            {
+                get
+                {
+                    if (Platform == OSPlatform.Windows) return "Windows";
+                    if (Platform == OSPlatform.Linux) return "Linux";
+                    return Platform == OSPlatform.OSX ? "OSX" : "Unknown";
+                }
+                set
+                {
+                    Platform = value switch
+                    {
+                        "Windows" => OSPlatform.Windows,
+                        "Linux" => OSPlatform.Linux,
+                        "OSX" => OSPlatform.OSX,
+                        _ => throw new ArgumentException($"Unknown platform: {value}")
+                    };
+                }
+            }
+
+            [XmlText]
+            public string Path
+            {
+                get => _path;
+                set => _path = value?.Trim();
+            }
+    
+            private string _path;
         }
     }
 }

--- a/Source/ModDefinition/ModContainer.cs
+++ b/Source/ModDefinition/ModContainer.cs
@@ -1,4 +1,6 @@
-﻿using FezEngine.Tools;
+﻿using System.Runtime.InteropServices;
+using Common;
+using FezEngine.Tools;
 using HatModLoader.Source.AssemblyResolving;
 using HatModLoader.Source.Assets;
 using HatModLoader.Source.FileProxies;
@@ -17,6 +19,8 @@ public class ModContainer : IDisposable
     public CodeMod CodeMod { get; internal set; }
     
     private IAssemblyResolver _assemblyResolver;
+    
+    private readonly List<IntPtr> _nativeLibraryHandles = new();
 
     public ModContainer(IFileProxy fileProxy, Metadata metadata)
     {
@@ -30,6 +34,8 @@ public class ModContainer : IDisposable
         {
             _assemblyResolver = new ModInternalAssemblyResolver(this);
             AssemblyResolverRegistry.Register(_assemblyResolver);
+            AppDomain.CurrentDomain.ProcessExit += UnloadNativeLibraries;
+            LoadNativeLibraries();
             CodeMod?.Initialize(game);
         }
     }
@@ -57,6 +63,59 @@ public class ModContainer : IDisposable
         if (_assemblyResolver != null)
         {
             AssemblyResolverRegistry.Unregister(_assemblyResolver);
+        }
+    }
+    
+    private void UnloadNativeLibraries(object sender, EventArgs e)
+    {
+        lock (_nativeLibraryHandles)
+        {
+            foreach (var library in _nativeLibraryHandles)
+            {
+                FileProxy.UnloadLibrary(library);
+            }
+        }
+    }
+    
+    private void LoadNativeLibraries()
+    {
+        if (Metadata.NativeDependencies == null || Metadata.NativeDependencies.Length == 0)
+        {
+            return;
+        }
+        
+        var platformSpecific = Metadata.NativeDependencies
+            .Where(library => RuntimeInformation.IsOSPlatform(library.Platform))
+            .Where(library => RuntimeInformation.ProcessArchitecture == library.Architecture)
+            .ToArray();
+
+        if (platformSpecific.Length == 0)
+        {
+            var os = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Windows"
+                : RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "Linux"
+                : RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "OSX"
+                : "Unknown";
+            var cpu = RuntimeInformation.ProcessArchitecture;
+            throw new PlatformNotSupportedException($"There're no native libraries found for " +
+                                                    $"Platform=\"{os}\" Architecture=\"{cpu}\"");
+        }
+
+        foreach (var library in platformSpecific)
+        {
+            if (!FileProxy.FileExists(library.Path))
+            {
+                throw new DllNotFoundException($"There's no native library found at: {library.Path}");
+            }
+
+            var libraryHandle = FileProxy.LoadLibrary(library.Path);
+            if (libraryHandle == IntPtr.Zero)
+            {
+                Logger.Log(Metadata.Name, $"Unable to load native library: {library.Path}"); 
+                continue;
+            }
+            
+            Logger.Log(Metadata.Name, $"Native library successfully loaded: {library.Path}"); 
+            _nativeLibraryHandles.Add(libraryHandle);
         }
     }
 }

--- a/Source/NativeLibraryInterop.cs
+++ b/Source/NativeLibraryInterop.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.InteropServices;
+
+namespace HatModLoader.Source
+{
+    public static class NativeLibraryInterop
+    {
+        [DllImport("kernel32", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern IntPtr LoadLibrary(string lpFileName);
+
+        [DllImport("libdl", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr Dlopen(string fileName, int flags);
+
+        [DllImport("kernel32", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern bool FreeLibrary(IntPtr hModule);
+
+        [DllImport("libdl", CallingConvention = CallingConvention.Cdecl)]
+        private static extern int Dlclose(IntPtr handle);
+            
+        public static IntPtr Load(string fileName)
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? LoadLibrary(fileName)
+                : Dlopen(fileName, 1);
+        }
+            
+        public static bool Free(IntPtr libraryHandle)
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? FreeLibrary(libraryHandle)
+                : Dlclose(libraryHandle) == 0;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for loading native libraries, if the code mod requires this.

To do this, alongside with packaging DLL libraries for a mod, you must specify them in `Metadata.xml` as follows:
```xml
<Metadata>
	<NativeDependencies>
		<NativeLibrary Architecture="..." Platform="...">[LOCAL_PATH_TO_DLL]</NativeLibrary>
	</NativeDependencies>
</Metadata>
```

Platforms: `Windows`, `Linux`, `OSX`.
Architectures: `X86` (default for FEZ executable), `X64`, `Arm64`.

It is worth noting that if the mod is packaged in ZIP, a temporary file is created before downloading, after which the OS allows it to be loaded. The code contains a mechanism that deletes this file after the game process is complete. But I'm not sure if it will work as intended if the game suddenly crashes.